### PR TITLE
Refactor: load cube scripts via main module

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
   ],
   "parserOptions": {
     "ecmaVersion": 2022,
-    "sourceType": "script"
+    "sourceType": "module"
   },
   "rules": {
     "indent": ["warn", "tab", { "SwitchCase": 1 }],

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ A fully interactive 3D Rubik's Cube implementation built with pure JavaScript an
 
 The repository separates source files from generated assets so it's clear what should be edited versus what is produced by the build pipeline:
 
-- `src/index.html` – main HTML entry point with button wiring
+- `src/index.html` – main HTML entry point that loads the module-based scripts
+- `src/js/main.js` – orchestrates cube rendering and button initialization
 - `src/js/cube.js` – JavaScript logic that renders and animates the cube
+- `src/js/buttons.js` – builds the rotation controls
 - `src/styles/cube.css` – authoring CSS before PostCSS processing
 - `public/` – compiled/static assets ready to be served (generated via `pnpm run build` and excluded from version control)
 

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "rubiks-cube-3d",
   "version": "1.0.0",
   "description": "3D Rubik's Cube implementation in JavaScript",
-  "main": "src/js/cube.js",
+  "main": "src/js/main.js",
   "scripts": {
     "lint": "eslint \"src/js/**/*.js\"",
     "lint:fix": "eslint \"src/js/**/*.js\" --fix",
     "lint:check": "eslint --print-config src/js/cube.js",
     "css:build": "mkdir -p public/styles && postcss src/styles/cube.css -o public/styles/cube.css",
     "css:watch": "mkdir -p public/styles && postcss src/styles/cube.css -o public/styles/cube.css --watch",
-    "copy:assets": "mkdir -p public/js && cp src/index.html public/index.html && cp src/js/cube.js public/js/cube.js",
+    "copy:assets": "mkdir -p public/js && cp src/index.html public/index.html && cp -r src/js/. public/js/",
     "build": "pnpm run copy:assets && pnpm run css:build",
     "dev": "pnpm run copy:assets && pnpm run css:watch"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -5,40 +5,11 @@
 		<title>3D rubiks cube</title>
                 <link rel="stylesheet" href="./styles/cube.css">
 	</head>
-	<body>
-		<div id="container"></div>
-                <script src="./js/cube.js"></script>
+        <body>
+                <div id="container"></div>
+                <script type="module" src="./js/main.js"></script>
 
-		<div id="but_cont"></div>
-		<div id="but_cont_back"></div>
-
-		<script>
-			const but_cont = document.getElementById("but_cont");
-			const but_cont_back = document.getElementById("but_cont_back");
-
-			function createRotateButton(rotName, forward) {
-				const button = document.createElement("div");
-				button.id = rotName;
-				if (forward) button.id += "-back";
-				button.id += "_rotate";
-				button.className = "rotate_button";
-				button.addEventListener("click", function () { rotate(rotName + (forward ? "'" : "")); }, false);
-
-				let title = rotName.toUpperCase();
-				if (forward) title += "'";
-				button.innerHTML = title;
-
-				if (forward)
-					but_cont_back.appendChild(button);
-				else but_cont.appendChild(button);
-			}
-
-			const buttonNames = ["f", "l", "u", "x", "y", "z"];
-
-			for (let index = 0; index < buttonNames.length; index++) {
-				createRotateButton(buttonNames[index]);
-				createRotateButton(buttonNames[index], true);
-			}
-		</script>
-	</body>
+                <div id="but_cont"></div>
+                <div id="but_cont_back"></div>
+        </body>
 </html>

--- a/src/js/buttons.js
+++ b/src/js/buttons.js
@@ -1,0 +1,32 @@
+import { rotate } from "./cube.js";
+
+function createRotateButton(rotName, forward, targetContainer) {
+	const button = document.createElement("div");
+	button.id = `${rotName}${forward ? "-back" : ""}_rotate`;
+	button.className = "rotate_button";
+	button.addEventListener("click", () => {
+		rotate(rotName + (forward ? "'" : ""));
+	}, false);
+
+	const title = `${rotName.toUpperCase()}${forward ? "'" : ""}`;
+	button.innerHTML = title;
+
+	targetContainer.appendChild(button);
+}
+
+const BUTTON_NAMES = ["f", "l", "u", "x", "y", "z"];
+
+export function initButtons() {
+	const frontContainer = document.getElementById("but_cont");
+	const backContainer = document.getElementById("but_cont_back");
+
+	if (!frontContainer || !backContainer) {
+		return;
+	}
+
+	for (let index = 0; index < BUTTON_NAMES.length; index++) {
+		const buttonName = BUTTON_NAMES[index];
+		createRotateButton(buttonName, false, frontContainer);
+		createRotateButton(buttonName, true, backContainer);
+	}
+}

--- a/src/js/cube.js
+++ b/src/js/cube.js
@@ -153,12 +153,11 @@ function endRotation() {
 	rotCubies = [];
 }
 
-// eslint-disable-next-line no-unused-vars
-function rotate(move) {	
+export function rotate(move) {
 	rotType = move[0];
 	rotation = rotations[rotType];
 	rotBack = (move[1] === "'");
-	
+
 	console.log(`rotation ${move}`);
 	if (!rotating) startRotation(move);
 }
@@ -209,11 +208,11 @@ function createPlane() {
 	plane.addEventListener("webkitTransitionEnd", endRotation, false);
 }
 
-function init() {
+export function initCube() {
 	cube = document.createElement("div");
 	cube.id = "cube";
 	container.appendChild(cube);
-	
+
 	/*cube.addEventListener("mousedown", mousedown, false);
 	cube.addEventListener("mouseup", mouseup, false);
 	cube.addEventListener("mousemove", mousemove, false);
@@ -226,8 +225,6 @@ function init() {
 
 	createPlane();
 }
-
-init();
 
 /* turning */
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,0 +1,13 @@
+import { initCube } from "./cube.js";
+import { initButtons } from "./buttons.js";
+
+function boot() {
+	initCube();
+	initButtons();
+}
+
+if (document.readyState === "loading") {
+	document.addEventListener("DOMContentLoaded", boot);
+} else {
+	boot();
+}


### PR DESCRIPTION
## Summary
- add a `src/js/main.js` entry module that boots the cube and rotation controls after the DOM is ready
- convert the cube and button scripts to ES modules and remove reliance on globals while keeping behavior the same
- update the HTML loader, lint config, docs, and asset copy script so the new module structure works with the existing build pipeline

## Testing
- pnpm run lint
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3ee2e8e5c83278e3658577965e877